### PR TITLE
Add beep when agent thinks or runs commands

### DIFF
--- a/agents/src/multimodal/multimodal_agent.ts
+++ b/agents/src/multimodal/multimodal_agent.ts
@@ -29,7 +29,7 @@ import * as llm from '../llm/index.js';
 import { log } from '../log.js';
 import type { MultimodalLLMMetrics } from '../metrics/base.js';
 import { TextAudioSynchronizer, defaultTextSyncOptions } from '../transcription.js';
-import { findMicroTrackId } from '../utils.js';
+import { findMicroTrackId, beep } from '../utils.js';
 import { AgentPlayout, type PlayoutHandle } from './agent_playout.js';
 
 /**
@@ -371,6 +371,7 @@ export class MultimodalAgent extends EventEmitter {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this.#session.on('function_call_started', (ev: any) => {
+        beep();
         this.#pendingFunctionCalls.add(ev.callId);
         this.#updateState();
       });
@@ -545,6 +546,9 @@ export class MultimodalAgent extends EventEmitter {
     if (this.room?.isConnected && this.room.localParticipant) {
       const currentState = this.room.localParticipant.attributes![AGENT_STATE_ATTRIBUTE];
       if (currentState !== state) {
+        if (state === 'thinking') {
+          beep();
+        }
         this.room.localParticipant.setAttributes({
           [AGENT_STATE_ATTRIBUTE]: state,
         });

--- a/agents/src/pipeline/pipeline_agent.ts
+++ b/agents/src/pipeline/pipeline_agent.ts
@@ -42,7 +42,13 @@ import type { SentenceTokenizer, WordTokenizer } from '../tokenize/tokenizer.js'
 import { TextAudioSynchronizer, defaultTextSyncOptions } from '../transcription.js';
 import type { TTS } from '../tts/index.js';
 import { TTSEvent, StreamAdapter as TTSStreamAdapter } from '../tts/index.js';
-import { AsyncIterableQueue, CancellablePromise, Future, gracefullyCancel } from '../utils.js';
+import {
+  AsyncIterableQueue,
+  CancellablePromise,
+  Future,
+  gracefullyCancel,
+  beep,
+} from '../utils.js';
 import { type VAD, type VADEvent, VADEventType } from '../vad.js';
 import type { SpeechSource, SynthesisHandle } from './agent_output.js';
 import { AgentOutput } from './agent_output.js';
@@ -451,6 +457,9 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
   }
 
   #updateState(state: AgentState, delay = 0) {
+    if (state === 'thinking') {
+      beep();
+    }
     const runTask = (delay: number): CancellablePromise<void> => {
       return new CancellablePromise(async (resolve, _, onCancel) => {
         let cancelled = false;
@@ -805,6 +814,7 @@ export class VoicePipelineAgent extends (EventEmitter as new () => TypedEmitter<
       this.emit(VPAEvent.FUNCTION_CALLS_COLLECTED, newFunctionCalls);
       const calledFuncs: FunctionCallInfo[] = [];
       for (const func of newFunctionCalls) {
+        beep();
         const task = func.func.execute(func.params).then(
           (result) => ({ name: func.name, toolCallId: func.toolCallId, result }),
           (error) => ({ name: func.name, toolCallId: func.toolCallId, error }),

--- a/agents/src/utils.ts
+++ b/agents/src/utils.ts
@@ -339,3 +339,8 @@ export class AudioEnergyFilter {
     return false;
   }
 }
+
+/** Emit a beep through stdout. */
+export const beep = () => {
+  process.stdout.write('\x07');
+};


### PR DESCRIPTION
## Summary
- expose a `beep` helper in utils
- beep when agent state becomes `thinking`
- beep whenever executing AI functions

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz)*

------
